### PR TITLE
Fix cache init timing

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -2,8 +2,11 @@ const { generateOgImages } = require("./src/generator");
 const { config } = require("./src/config");
 const { imageGenerationJobCache } = require("./src/cache");
 
-exports.onPreInit = async ({ cache }, pluginConfig) => {
+exports.onPreInit = async (pluginConfig) => {
   config.init(pluginConfig);
+};
+
+exports.onPreBootstrap = async ({ cache }) => {
   await imageGenerationJobCache.init(cache);
 };
 


### PR DESCRIPTION
Since https://github.com/gatsbyjs/gatsby/pull/26810 , `cache` object is not accessible
in `onPreInit`. This commit moves cache initialization to `onPreBootstrap`.

Fixes #5