### PR TITLE
Use path to identify createOpenGraphImage onCreatePage

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -8,7 +8,8 @@ exports.onPreInit = async ({ cache }, pluginConfig) => {
 };
 
 exports.onCreatePage = async ({ page, cache }) => {
-  if (!!page.context.ogImage && !!page.context.ogImage["__ogImageGenerationContext"]) {
+  const { componentGenerationDir } = config.getConfig()
+  if (page.path.startsWith(`/${componentGenerationDir}/`)) {
     await imageGenerationJobCache.add(cache, page.context.ogImage["__ogImageGenerationContext"]);
   }
 };


### PR DESCRIPTION
Since normal `createPage`'s `context` can be set the same as `createOpenGraphImage`'s
internal `createPage`, unnecessary image generation job is enqueued to the cache and
it causes multiple image genarations.

This commit, instead, uses `path` because `createOpenGraphImage` always sets it with
prefix of `componentGenerationDir`. Thus, it can easily identify the onCreatePage event
only from `createOpenGraphImage`.

Fixes #2