### PR TITLE
Use recursive option with mkdir when creating target image dir

### DIFF
--- a/src/generator.js
+++ b/src/generator.js
@@ -44,7 +44,7 @@ const ensureThatImageDirExists = (path) => {
     fs.statSync(targetDir);
   } catch (err) {
     if (err.code === "ENOENT") {
-      fs.mkdirSync(targetDir);
+      fs.mkdirSync(targetDir, { recursive: true });
     }
   }
 };


### PR DESCRIPTION
When using a nested path to store the generated images like `path: '/foo/bar/og-images/image.png'`, I run into:

  Error: ENOENT: no such file or directory, mkdir 'public/foo/bar/og-images'

  - node:fs:1009 Object.mkdirSync
    node:fs:1009:3

  - generator.js:48 ensureThatImageDirExists
    [gatsby]/[gatsby-plugin-ogi]/src/generator.js:48:10

My fix uses the new `recursive: true` option that was added to `mkdir` in NodeJS 10.12 (https://stackoverflow.com/a/40686853). Gatsby itself seems to be have been depending on NodeJS 10.13 for a while https://github.com/gatsbyjs/gatsby/commit/83d681abbbfe7b791a360c940864c071a443f8e6#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519 so that should be fine.