### PR TITLE
Allow user to choose waitUntil condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ exports.createPages = async ({ actions }) => {
       width: 400,
       height: 50,
     },
+    waitCondition: "networkidle0",
     context: {
       description: "a image created with gatsby-plugin-open-graph-images",
     },

--- a/e2e/gatsby-node.js
+++ b/e2e/gatsby-node.js
@@ -7,6 +7,7 @@ exports.createPages = async ({ actions, graphql }) => {
   createOpenGraphImage(createPage, {
     path: "/og-image/index.png",
     component: path.resolve(`src/templates/index-og-image.js`),
+    waitCondition: "networkidle0",
     size: {
       width: 400,
       height: 50

--- a/e2e/src/templates/artist.js
+++ b/e2e/src/templates/artist.js
@@ -2,6 +2,8 @@ import * as React from "react";
 import { graphql } from "gatsby";
 import { Helmet } from "react-helmet";
 
+const domain = "http://localhost:9000";
+
 const ArtistPage = ({ data, pageContext }) => {
   return (
     <>

--- a/index.js
+++ b/index.js
@@ -3,14 +3,15 @@ const { config } = require("./src/config");
 
 exports.createOpenGraphImage = (createPage, options) => {
   config.init(options)
-  const { defaultSize, componentGenerationDir } = config.getConfig();
+  const { defaultSize, componentGenerationDir, defaultWaitCondition } = config.getConfig();
   const { path, component, context } = options;
 
   const size = { ...defaultSize, ...(options.size || {}) };
+  const waitCondition = options.waitCondition ? options.waitCondition : defaultWaitCondition;
   const componentPath = join(componentGenerationDir, encodeURIComponent(path.split("/").join("")));
   const imgPath = join("public", path);
 
-  const generationContext = { componentPath, imgPath, size };
+  const generationContext = { componentPath, imgPath, size, waitCondition };
   const ogImageMetaData = { path, size, __ogImageGenerationContext: generationContext };
 
   createPage({

--- a/src/config.js
+++ b/src/config.js
@@ -4,6 +4,7 @@ exports.config = (() => {
       width: 1200,
       height: 630,
     },
+    defaultWaitCondition: 'networkidle2',
     componentGenerationDir: "__generated",
   };
 

--- a/src/generator.js
+++ b/src/generator.js
@@ -10,11 +10,11 @@ exports.generateOgImages = async (imageGenerationJobs) => {
   const page = await browser.newPage();
 
   for (const imageGenerationJob of imageGenerationJobs) {
-    const { componentPath, imgPath, size } = imageGenerationJob;
+    const { componentPath, imgPath, size, waitCondition } = imageGenerationJob;
     const componentUrl = `${servingUrl}/${componentPath}`;
 
     await page.setViewport(size);
-    await page.goto(componentUrl, { 'waitUntil' : 'networkidle2' });
+    await page.goto(componentUrl, { 'waitUntil' : waitCondition });
 
     ensureThatImageDirExists(imgPath);
     await page.screenshot({ path: imgPath, clip: { x: 0, y: 0, ...size } });


### PR DESCRIPTION
This allows the user to choose a `waitUntil` condition for Puppeteer. It's backwards compatible, but allows the option to have Puppeteer wait longer to accommodate exceptionally slow-loading resources. 

Fixes #14 